### PR TITLE
made unlocking of credits to be performed in background

### DIFF
--- a/backend/apps/activities/serializers.py
+++ b/backend/apps/activities/serializers.py
@@ -4,27 +4,27 @@ from datetime import date
 class ActivitiesSerializer(serializers.ModelSerializer):
     class Meta:
         model = Activity
-        fields = ['id', 'user', 'duration', 'verification_proof','status', 'location', 'activity_date', 'description', 'activity']
-        read_only_field= ['id', 'user']
+        fields = ['id', 'user', 'duration', 'verification_proof','status', 'location', 'activity_date', 'description', 'activity', 'verified_on']
+        read_only_fields= ['id', 'verified_on', 'status']
         
-        def validate_verification_proof(self, value):
-            max_size = 2 * 1024 * 1024
-            if value.size > max_size:
-                raise serializers.ValidationError('Invalid image size')
+    def validate_verification_proof(self, value):
+        max_size = 2 * 1024 * 1024
+        if value.size > max_size:
+            raise serializers.ValidationError('Image size too large')
             
-            allowed_mime_types = ['image/jpeg', 'image/png']
-            if value.content_type not in allowed_mime_types:
-                raise serializers.ValidationError('Only png or jpeg formats are allowed')
+        allowed_mime_types = ['image/jpeg', 'image/png']
+        if value.content_type not in allowed_mime_types:
+            raise serializers.ValidationError('Only png or jpeg formats are allowed')
             
             
-            from PIL import Image
-            img = Image.open(value)
-            if img.width > 2000 or img.height > 2000:
-                raise serializers.ValidationError("Image dimensions too large")
+        from PIL import Image
+        img = Image.open(value)
+        if img.width > 2000 or img.height > 2000:
+            raise serializers.ValidationError("Image dimensions too large")
 
-            return value
+        return value
                     
-        def validate_activity_date(self, value):
-            if value > date.today():
-                raise serializers.ValidationError("Cannot add an activity of a future date")
-            return value
+    def validate_activity_date(self, value):
+        if value > date.today():
+            raise serializers.ValidationError("Cannot add an activity of a future date")
+        return value

--- a/backend/apps/activities/tasks.py
+++ b/backend/apps/activities/tasks.py
@@ -1,9 +1,19 @@
 from apps.users.models import CustomUser
 from django.db import transaction
 
+from celery import shared_task
+import logging
+from datetime import timedelta
 
 
-def unlock_credits(activity):
+logger = logging.getLogger(__name__)
+
+
+
+@shared_task()
+def unlock_credits(activity_id):
+    from .models import Activity
+    activity = Activity.objects.get(id=activity_id)
     #guiding to points :     #1hr coding time = 10 points
     duration_in_hrs =(activity.duration / 60)
     user_profile =  activity.user.profile
@@ -18,7 +28,10 @@ def unlock_credits(activity):
                 user_profile.locked_credits -= points_to_unlock  
                 user_profile.eco_credits += points_to_unlock 
                 user_profile.save()
+                logger.info(f"Added eco-credits for user {user_profile} as {user_profile.eco_credits }")
+
     except Exception as e:
+        logger.error(f"Error occurred {str(e)}")
         return(str(e))
     
     return points_to_unlock

--- a/backend/apps/activities/views.py
+++ b/backend/apps/activities/views.py
@@ -6,15 +6,16 @@ from rest_framework.decorators import action
 from rest_framework.response import Response
 from apps.users.models import CustomUser
 from datetime import datetime
-from .utils import unlock_credits
+from .tasks import unlock_credits
 from rest_framework.decorators import permission_classes
-from rest_framework.permissions import IsAuthenticated, IsAdminUser
+from rest_framework.permissions import IsAuthenticated, IsAdminUser, IsAuthenticated
 
 # Create your views here.
 
 class ActivitiesViewSet(viewsets.ModelViewSet):
     queryset = Activity.objects.all()
     serializer_class = ActivitiesSerializer
+    permission_classes = [IsAuthenticated]
     
     def create(self, request, *args, **kwargs):
             response = super().create(request, *args, **kwargs)
@@ -36,15 +37,19 @@ class ActivitiesViewSet(viewsets.ModelViewSet):
                 activity.verified_on = datetime.now()
                 activity.save()
                 
-                unlock_credits(activity) #performs unlocking the credit
+                unlock_credits.delay(activity.id) #performs unlocking the credit
                 serializer = self.get_serializer(activity)
 
                 return Response(
-                            {"message": f"Activity verified successfully, {serializer.data}"},
+                            {"success": True, 
+                             "data": serializer.data
+                             },
                             status=status.HTTP_201_CREATED,
                 )
             return Response(
-                            {"message": f"Activity already verified, {serializer.data}"},
+                            {"success": True,
+                             "data": serializer.data
+                             },
                             status=status.HTTP_400_BAD_REQUEST,
                 )
             


### PR DESCRIPTION
**What does this merge request do** 
1. Moved the credit unlocking logic into a Celery task (unlock_credits) for better responsiveness.
Activities are now verified in the request/response cycle, while the credit unlocking runs in the background.

 2. Serializer fixes

- Corrected read_only_field → read_only_fields to properly enforce system-managed fields.
- Adjusted placement of validation methods (validate_verification_proof, validate_activity_date) to ensure they run correctly.
- Added verified_on as a read-only field so it is system-controlled but still visible in API responses.