### PR TITLE
Automatically associate authenticated user on Activity creation

### DIFF
--- a/backend/apps/activities/views.py
+++ b/backend/apps/activities/views.py
@@ -17,6 +17,9 @@ class ActivitiesViewSet(viewsets.ModelViewSet):
     serializer_class = ActivitiesSerializer
     permission_classes = [IsAuthenticated]
     
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)
+
     def create(self, request, *args, **kwargs):
             response = super().create(request, *args, **kwargs)
             return Response(

--- a/backend/docs/activities.MD
+++ b/backend/docs/activities.MD
@@ -16,9 +16,6 @@ POST request to f{base_url}/api/activities/
 content-type : application/json
 Payload:
    {
-     "success": true,
-    "data": {
-    "user": 1,
     "duration": 60,
     "verification_proof": .png,
     "status": null,
@@ -26,7 +23,7 @@ Payload:
     "activity_date": 2025-09-07,
     "description": "",
     "activity": "family_meetup"
-    }
+    
 }
 
 Response:


### PR DESCRIPTION
**What does this merge request do**
   Automatically associate authenticated user on Activity creation

Description:
Updated ActivitiesViewSet to automatically attach the authenticated user when creating a new Activity.
Added perform_create() to assign request.user to the user field, so the user does not need to be sent in the request payload.

Benefits:
Simplifies API usage — clients no longer need to provide the user in the payload.